### PR TITLE
DB antiPattern 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/db_anti_pattern/README.md
+++ b/db_anti_pattern/README.md
@@ -1,0 +1,3 @@
+# Zenn CLI
+
+* [📘 How to use](https://zenn.dev/zenn/articles/zenn-cli-guide)

--- a/db_anti_pattern/articles/db_anti_pattern_1.md
+++ b/db_anti_pattern/articles/db_anti_pattern_1.md
@@ -1,0 +1,91 @@
+---
+title: "カンマ区切りで格納されいるDB設計" # 記事のタイトル
+emoji: "💭" # アイキャッチとして使われる絵文字（1文字だけ）
+type: "tech" # tech: 技術記事 / idea: アイデア記事
+topics: ["SQL","DB"] # タグ。["markdown", "rust", "aws"]のように指定する
+published: false # 公開設定（falseにすると下書き）
+---
+検索しやすいようにタグを設定して記事を投稿できるサービス。
+「タグ名を変更したが、変更前の名前のタグがついた記事がある」と問い合わせがあったのでDB設計を調査してみた。
+
+## 現状のテーブル構造
+
+```mermaid
+erDiagram
+    "Post(投稿)" {
+        id varchar
+        text varchar
+        tags varchar
+    }
+```
+`tags`に`tagA,tagB,tagC`のようにカンマ区切りでタグの情報が格納されていた。
+![](https://storage.googleapis.com/zenn-user-upload/41f11c307453-20240912.png)
+複数タグが設定されている投稿の更新がうまくいっていないようだ。
+調べたところ、複数の値を持つ属性をカンマ区切りのリストで管理することは「ジェイウォーク(信号無視)」と呼ばれるDB設計のアンチパターンであることがわかった。
+
+## 問題点
+この設計には以下のような問題が発生してしまう。
+- タグの変更が複雑になる
+タグ名を変更する場合、カンマ区切りの文字列から該当タグを抽出して置き換える必要があるために複雑なクエリになってしまう。
+```
+UPDATE Post
+SET tags = REGEXP_REPLACE(tags, '(^|,)tagA(,|$)', '\\1newTagA\\2')
+WHERE tags REGEXP '(^|,)tagA(,|$)';
+```
+
+- 不正な値や重複、データ不整合が発生しやすい
+カンマ区切りのリストには**FK(外部キー)制約**を設定できないので、DB側で不正なデータのチェックができず重複やデータ不整合が発生しやすくなってしまう。
+
+- 検索が非効率
+タグを使って検索や結合（JOIN）する際、カンマ区切りの値を使うことでクエリが複雑化し、パフォーマンスが低下。
+```
+SELECT *
+FROM Post AS p INNER JOIN Tags t
+    ON p.tags REGEXP CONCAT('(^|,)', t.tag_name, '(,|$)')
+WHERE p.id = 'P000001'
+```
+
+- インデックスが効かない
+`tags`に対してインデックスが適用できず、特定のタグを検索する際にはLIKE句を使うことになってしまい、パフォーマンスが低下。
+```
+SELECT *
+FROM Post
+WHERE tags LIKE '%tagA%';
+```
+https://zenn.dev/suzuki_hoge/books/2022-12-database-index-9520da88d02c4f/viewer/4-feature
+
+
+
+
+## どのように解決するか
+`Post`から`tags`を正規化して別テーブルに分ける。
+タグと投稿は`多対多`の関係になるため、これを管理するために中間テーブルを作成。
+```mermaid
+erDiagram
+    Post {
+        post_id varchar PK
+        text varchar
+    }
+
+    Tags {
+        tag_id　varchar PK
+        name varchar
+    }
+
+    PostTags {
+        post_id varchar FK
+        tag_id varchar FK
+    }
+
+    Post ||--o{ PostTags : "has"
+    Tags ||--o{ PostTags : "has"
+```
+正規化により、タグの検索や結合クエリがシンプルになってインデックスも適用できるため、パフォーマンスが向上する。
+```
+SELECT *
+FROM Post AS p INNER JOIN PostTags pt
+    ON p.post_id = pt.post_id
+WHERE p.post_id = 'P000001'
+```
+## 参考文献
+https://www.oreilly.co.jp/books/9784873115894/

--- a/db_anti_pattern/articles/db_anti_pattern_2.md
+++ b/db_anti_pattern/articles/db_anti_pattern_2.md
@@ -1,0 +1,97 @@
+---
+title: "複数列属性のDB設計" # 記事のタイトル
+emoji: "💭" # アイキャッチとして使われる絵文字（1文字だけ）
+type: "tech" # tech: 技術記事 / idea: アイデア記事
+topics: ["SQL","DB"] # タグ。["markdown", "rust", "aws"]のように指定する
+published: false # 公開設定（falseにすると下書き）
+---
+転職のためのユーザーと企業をマッチングするサービス。
+当初はスキルを1個しか登録できない予定だったが、仕様変更により3個まで登録できるようになったため、とりあえずスキルidカラムを3個に増やして対応した。
+
+## テーブル構造
+
+```mermaid
+erDiagram
+    "Users(変更前)" {
+        user_id varchar PK
+        name varchar
+        skill1id varchar FK
+    }
+    "Users(変更後)" {
+        user_id varchar PK
+        name varchar
+        skill1id varchar FK
+        skill2id varchar FK
+        skill3id varchar FK
+    }
+
+    Skills {
+        id　varchar PK
+        name varchar
+    }
+
+    "Users(変更前)" ||--o{ Skills : "has"
+```
+変更対応後、「動作が遅くなった」「2個しか登録できない」といった問い合わせが増えたため、
+設計を見直すことにした。
+
+## 問題点
+この設計には以下のような問題が発生してしまうことがわかった。
+### 検索が非効率
+特定の値が存在するUsersを検索する場合、3列すべて取得しないといけない。
+```
+SELECT * FROM Users
+WHERE skill1id = 'スキルA'
+OR skill2id = 'スキルA'
+OR skill3id = 'スキルA';
+```
+
+### データが重複してしまう可能性がある
+ユニーク制約を設定することが難しいため、skill1id, skill2id, skill3idに重複したデータが入ってしまう可能性がある。
+
+### タグの登録数を増やす場合に問題が発生する可能性がある
+- テーブルに関係するすべてのクエリの見直しが必要になる
+- テーブル全体をロックしないといけなくなってしまう可能性がある
+:::message
+サービスを停止しなければならない可能性がでてしまう
+:::
+
+## どのように解決するか
+`Users`から`Skills`の多対多関係を中間テーブルUserSkillsで管理することで、以下のような改善が可能だと考えられる。
+```mermaid
+erDiagram
+    Users {
+        user_id varchar PK
+        name varchar
+    }
+
+    Skills {
+        skill_id　varchar PK
+        name varchar
+    }
+
+    UserSkills {
+        post_id varchar FK
+        skill_id varchar FK
+    }
+
+    Users ||--o{ UserSkills : "has"
+    Skills ||--o{ UserSkills : "has"
+```
+### クエリの効率化
+JOINを使ったクエリによって、効率的にスキルを持つユーザーを取得できるようになる。
+スキルごとのユーザー検索において冗長なOR条件が不要となるため、効率的な検索が可能になる。
+```
+SELECT u.*
+FROM Users u
+JOIN UserSkills us ON u.user_id = us.user_id
+WHERE us.skill_id = 'スキルA';
+```
+### データ重複問題の解決
+中間テーブルである`UserSkills`に対して、`user_id`と`skill_id`の組み合わせにユニーク制約を付けることで、同じユーザーに同じスキルが複数回登録されるのを防ぐことができる。
+
+### スキルの拡張性
+テーブルを変更することなく登録数を増やすことができるため、サービスを停止せずに運用が可能になる。
+
+## 参考文献
+https://www.oreilly.co.jp/books/9784873115894/

--- a/db_anti_pattern/package-lock.json
+++ b/db_anti_pattern/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "db_anti_pattern",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "db_anti_pattern",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "zenn-cli": "^0.1.157"
+      }
+    },
+    "node_modules/zenn-cli": {
+      "version": "0.1.157",
+      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.157.tgz",
+      "integrity": "sha512-df1JPOwdf3r9dH3YvgiAzfPZllzSB140uXB3EaDtVvxGaDQ2pMsrqaHkhFM6TIAk5KkVX4afN3K4RUwL+S1gKw==",
+      "bin": {
+        "zenn": "dist/server/zenn.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    }
+  }
+}

--- a/db_anti_pattern/package.json
+++ b/db_anti_pattern/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "db_anti_pattern",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "zenn-cli": "^0.1.157"
+  }
+}


### PR DESCRIPTION
## 課題1-1

### 検索が非効率

特定の値が存在するPostを検索する場合、3列すべて取得しないといけない。

```sql
SELECT * FROM Post
WHERE tag1id = 'タグA'
OR tag2id = 'タグA'
OR tag3id = 'タグA';
```

### データが重複してしまう可能性がある

ユニーク制約を設定することが難しいため、tag1id, tag2id, tag3idに重複したデータが入ってしまう可能性がある

### タグの登録数を増やす場合に問題が発生する可能性がある

- テーブルに関係するすべてのクエリの見直しが必要になる
- テーブル全体をロックしないといけなくなってしまう可能性

※サービスを停止しなければならない可能性がでてしまう

## 課題2-1
`Users`から`Skills`の多対多関係を中間テーブル`UserSkills`で管理することで、以下のような改善が可能だと考えられる。

```mermaid
erDiagram
    Post {
        post_id varchar PK
        text varchar
    }

    Tags {
        tag_id　varchar PK
        name varchar
    }

    PostTags {
        post_id varchar FK
        tag_id varchar FK
    }

    Post ||--o{ PostTags : "has"
    Tags ||--o{ PostTags : "has"
```

### クエリの効率化

`tag1id,tag2id,tag3id` それぞれのインデックスではなく、`pt.post_id`の1つのインデックスとなるので効率よく検索が可能になる。

```sql
SELECT p.*
FROM Post p
JOIN PostTags pt ON p.post_id = pt.post_id
WHERE pt.tag_id = 'タグA';
```

### データ重複問題の解決

中間テーブルである`PostTags`に対して、`post_id`と`tag_id`の組み合わせにユニーク制約を付けることで、同じ投稿に同じタグが複数回登録されるのを防ぐことができる。

### スキルの拡張性

テーブルを変更することなく登録数を増やすことができるため、サービスを停止せずに運用が可能になる。

## 課題3-1

転職のためのユーザーと企業をマッチングするサービスを開発していると仮定する

- 「Users」テーブルを作成して「skillid」をカラムとして保持している
    - 当初はスキルを3個しか登録できない予定だったが、仕様変更により何個でも登録できるようになったため、とりあえずスキルidカラムを10個に増やした時にアンチパターンに陥る
   
アンチパターンに遭遇したことをイメージした記事
https://zenn.dev/ktom106/articles/69b06a4fdae922
